### PR TITLE
Refactor interactor to use dependency injection

### DIFF
--- a/src/modules/choose-plan-page/hooks/index.ts
+++ b/src/modules/choose-plan-page/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useUserPaymentInfo'

--- a/src/modules/choose-plan-page/hooks/useUserPaymentInfo.tsx
+++ b/src/modules/choose-plan-page/hooks/useUserPaymentInfo.tsx
@@ -1,0 +1,15 @@
+import { useUser } from '../../../providers/user-provider';
+import { PaymentUserHook } from '../interactor.types';
+import { useMemo } from 'react';
+
+export const useUserPaymentInfo: PaymentUserHook = () => {
+	const { user } = useUser();
+
+	return useMemo(
+		() => ({
+			email: user.email,
+			subscription: user.subscription
+		}),
+		[user]
+	);
+};

--- a/src/modules/choose-plan-page/index.tsx
+++ b/src/modules/choose-plan-page/index.tsx
@@ -1,12 +1,18 @@
 import { Header } from "../../header";
+import { useRemoteConfig } from '../../providers/remote-config-provider';
+import { useGetSubscriptionProducts } from "../../use-cases/get-subscription-products";
+import { useUserPaymentInfo } from './hooks';
 import { usePaymentPageInteractor } from "./interactor";
 import { PaymentPageRouter } from "./router";
 import React from "react";
 
 export interface IProps {}
 export const PaymentPage: React.FC<IProps> = () => {
-  const interactor = usePaymentPageInteractor();
-  // const router = useRouter()
+	const interactor = usePaymentPageInteractor({
+		useSubscriptionProductsHook: useGetSubscriptionProducts,
+		useUserHook: useUserPaymentInfo,
+		useRemoteConfigHook: useRemoteConfig
+	});
 
   return (
     <PaymentPageRouter

--- a/src/modules/choose-plan-page/interactor.tsx
+++ b/src/modules/choose-plan-page/interactor.tsx
@@ -1,17 +1,15 @@
 // import { EDIT_FILENAME_LC_KEY, EDIT_FILE_LC_KEY } from '@/common/constants'
-import { useRemoteConfig } from "../../providers/remote-config-provider";
-import { useUser } from "../../providers/user-provider";
 import { API } from "../../services/api";
 import { ApiFile } from "../../services/api/types";
 import { generatePDFCover } from "../../use-cases/generate-pdf-cover";
 import {
   PaymentPlanId,
-  useGetSubscriptionProducts,
 } from "../../use-cases/get-subscription-products";
 import check from "./assets/check.svg";
 import cross from "./assets/cross.svg";
 import { useRouter } from "next/router";
 import React from "react";
+import { PaymentRemoteConfigHook, PaymentSubscriptionProductsHook, PaymentUserHook } from './interactor.types';
 
 export enum PAGE_LINKS {
   MAIN = "/",
@@ -93,21 +91,30 @@ export interface IPaymentPageInteractor {
   getPlans: (t: (key: string) => string) => Plan[];
   isPlansLoading: boolean;
 }
+type UsePaymentPageInteractorArguments = {
+	useSubscriptionProductsHook: PaymentSubscriptionProductsHook;
+	useUserHook: PaymentUserHook;
+	useRemoteConfigHook: PaymentRemoteConfigHook;
+};
 
-export const usePaymentPageInteractor = (): IPaymentPageInteractor => {
+export const usePaymentPageInteractor = ({
+	useSubscriptionProductsHook,
+	useUserHook,
+	useRemoteConfigHook
+}: UsePaymentPageInteractorArguments): IPaymentPageInteractor => {
   const router = useRouter();
   const [selectedPlan, setSelectedPlan] = React.useState<PaymentPlanId>(
     PaymentPlanId.MONTHLY_FULL
   );
-  const { products } = useGetSubscriptionProducts();
-  const { user } = useUser();
+  const { products } = useSubscriptionProductsHook();
+  const  user  = useUserHook();
 
   const [file, setFile] = React.useState<ApiFile>();
   const [imagePDF, setImagePDF] = React.useState<Blob | null>(null);
   const [isImageLoading, setIsImageLoading] = React.useState(false);
   const [fileLink, setFileLink] = React.useState<string | null>(null);
 
-  const { abTests, isRemoteConfigLoading } = useRemoteConfig();
+  const { abTests, isRemoteConfigLoading } = useRemoteConfigHook();
 
   const onCommentsFlip = () => {
     console.log("send event analytic0");

--- a/src/modules/choose-plan-page/interactor.types.ts
+++ b/src/modules/choose-plan-page/interactor.types.ts
@@ -1,0 +1,9 @@
+import { RemoteConfig } from '../../providers/remote-config-provider';
+import { User } from '../../providers/user-provider';
+import { Product } from '../../use-cases/get-subscription-products';
+
+export type PaymentSubscriptionProductsHook = () => {products: Product[]};
+
+export type PaymentUserHook = () => Pick<User, 'email' | 'subscription'>;
+
+export type PaymentRemoteConfigHook = () => Pick<RemoteConfig, 'abTests' | 'isRemoteConfigLoading'>;

--- a/src/providers/remote-config-provider/index.tsx
+++ b/src/providers/remote-config-provider/index.tsx
@@ -1,12 +1,14 @@
 import React, {useCallback, useContext, useEffect, useState} from "react";
 import { useRouter } from "next/router";
 
-interface RemoteConfigContext {
+export interface RemoteConfig {
   abTests: Record<string, string>
   featureFlags: Record<string, string>
   reloadConfig: () => void;
   isRemoteConfigLoading: boolean
 }
+
+interface RemoteConfigContext extends RemoteConfig {}
 
 const defaultContext: RemoteConfigContext = {
   abTests: {},


### PR DESCRIPTION
Refactored the usePaymentPageInteractor function in choose-plan-page to accept dependencies via arguments for better modularity and testability.